### PR TITLE
Added scale decoding for Uint64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	branch = v1.4.0
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/src/trie/substrate/ScaleCodec.sol
+++ b/src/trie/substrate/ScaleCodec.sol
@@ -5,6 +5,15 @@ pragma solidity ^0.8.17;
 import { Bytes, ByteSlice } from "../Bytes.sol";
 
 library ScaleCodec {
+    // Decodes a SCALE encoded uint64 by converting bytes (bid endian) to little endian format
+    function decodeUint64(bytes memory data) internal pure returns (uint64) {
+        uint64 number;
+        for (uint256 i = data.length; i > 0; i--) {
+            number = number + uint64(uint8(data[i - 1])) * uint64(2**(8 * (i - 1)));
+        }
+        return number;
+    }
+
     // Decodes a SCALE encoded uint256 by converting bytes (bid endian) to little endian format
     function decodeUint256(bytes memory data) internal pure returns (uint256) {
         uint256 number;


### PR DESCRIPTION
This PR adds a function to decode a scaled decoded uint64.  Also, it removed the submodule branch for `lib/forge-std` as that branch doesn't exist anymore.